### PR TITLE
Add Dockerfile to run Streamlit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use python:3.8-slim as the base image
+FROM python:3.8-slim
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy requirements.txt to the Docker image
+COPY requirements.txt .
+
+# Install dependencies from requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the project files to the Docker image
+COPY . .
+
+# Run the Streamlit application
+CMD ["streamlit", "run", "openvino.py"]

--- a/README.md
+++ b/README.md
@@ -41,3 +41,21 @@ Run the Streamlit application:
 ``` bash
 streamlit run openvino.py
 ```
+
+## Docker Instructions
+
+### Build Docker Image
+
+To build the Docker image, run the following command in the project directory:
+
+```bash
+docker build -t pdf-rag-system .
+```
+
+### Run Docker Container
+
+To run the Docker container, use the following command:
+
+```bash
+docker run -p 8501:8501 pdf-rag-system
+```


### PR DESCRIPTION
Add a Dockerfile to set up the environment and run the Streamlit application.

* **Dockerfile**
  - Use `python:3.8-slim` as the base image.
  - Set the working directory to `/app`.
  - Copy `requirements.txt` to the Docker image.
  - Install dependencies from `requirements.txt`.
  - Copy the project files to the Docker image.
  - Run the Streamlit application using `CMD`.

* **README.md**
  - Add instructions to build the Docker image.
  - Add instructions to run the Docker container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Alexalen0/RAG_is_all_you_need/pull/2?shareId=fa4b633e-8b2f-4ef0-8faf-79804b7ed0f5).